### PR TITLE
Delete by Objectids

### DIFF
--- a/src/model/apply-edits/index.js
+++ b/src/model/apply-edits/index.js
@@ -49,7 +49,7 @@ export class ApplyEdits {
     this.adds = [];
     this.deletes = [];
     this.updates = [];
-    this.useGlobalIds = true;
+    this._useGlobalIds = true;
   }
 
   add(features) {
@@ -68,12 +68,12 @@ export class ApplyEdits {
   }
 
   useGlobalIds() {
-    this.useGlobalIds = true;
+    this._useGlobalIds = true;
     return this;
   }
 
   useObjectIds() {
-    this.useGlobalIds = false;
+    this._useGlobalIds = false;
     return this;
   }
 
@@ -91,13 +91,23 @@ export class ApplyEdits {
   }
 
   async exec() {
+
+    let deleteIds = null
+    if (this.deletes.length) {
+      if (this._useGlobalIds) {
+        deleteIds = this.deletes.map(id => `"${id}"`).join(',');
+      } else {
+        deleteIds = this.deletes.map(id => `${id}`).join(',');
+      }
+    }
+
     const query = {
       f: 'json',
-      useGlobalIds: this.useGlobalIds,
+      useGlobalIds: this._useGlobalIds,
       rollbackOnFailure: false,
       adds: this.adds.length ? JSON.stringify(this.adds) : null,
       updates: this.updates.length ? JSON.stringify(this.updates) : null,
-      deletes: this.deletes.length ? this.deletes.map(id => `"${id}"`).join(',') : null,
+      deletes: deleteIds,
     };
 
     const editsResult = await requestWithRetry(`${this.featureLayer.url}/applyEdits`, {

--- a/src/model/apply-edits/index.js
+++ b/src/model/apply-edits/index.js
@@ -49,7 +49,7 @@ export class ApplyEdits {
     this.adds = [];
     this.deletes = [];
     this.updates = [];
-    this._useGlobalIds = true;
+    this.shouldUseGlobalIds = true;
   }
 
   add(features) {
@@ -68,12 +68,12 @@ export class ApplyEdits {
   }
 
   useGlobalIds() {
-    this._useGlobalIds = true;
+    this.shouldUseGlobalIds = true;
     return this;
   }
 
   useObjectIds() {
-    this._useGlobalIds = false;
+    this.shouldUseGlobalIds = false;
     return this;
   }
 
@@ -94,7 +94,7 @@ export class ApplyEdits {
 
     let deleteIds = null
     if (this.deletes.length) {
-      if (this._useGlobalIds) {
+      if (this.shouldUseGlobalIds) {
         deleteIds = this.deletes.map(id => `"${id}"`).join(',');
       } else {
         deleteIds = this.deletes.map(id => `${id}`).join(',');
@@ -103,7 +103,7 @@ export class ApplyEdits {
 
     const query = {
       f: 'json',
-      useGlobalIds: this._useGlobalIds,
+      useGlobalIds: this.shouldUseGlobalIds,
       rollbackOnFailure: false,
       adds: this.adds.length ? JSON.stringify(this.adds) : null,
       updates: this.updates.length ? JSON.stringify(this.updates) : null,


### PR DESCRIPTION
the method `.useGlobalIds` was overwritten in constructor with the boolean datafield `this.useGlobalIds = true`, making it impossible to call (lets face it, the function is useless anyway 😄 ).

`.useObjectIds()` produced errors when deleting features, since the objectids got wrapped in quotes. So its deciding now which mode is used and only wrap globalIds in quotes, but leaving objectids as numbers