### PR TITLE
Bugfix/esri object id field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgoose",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "",
   "main": "dist/arcgoose.js",
   "module": "dist/arcgoose.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgoose",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "",
   "main": "dist/arcgoose.js",
   "module": "dist/arcgoose.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgoose",
-  "version": "0.3.4",
+  "version": "0.3.7",
   "description": "",
   "main": "dist/arcgoose.js",
   "module": "dist/arcgoose.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgoose",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "",
   "main": "dist/arcgoose.js",
   "module": "dist/arcgoose.js",

--- a/src/model/feature-layer.js
+++ b/src/model/feature-layer.js
@@ -25,9 +25,6 @@ const getQueryFromQueryObject = queryObject => Object.keys(queryObject)
   .join(' AND ');
 
 
-const getFieldsFromSchema = schema => Object.keys(schema.properties);
-
-
 export class FeatureLayer {
   constructor({
     url,
@@ -49,7 +46,7 @@ export class FeatureLayer {
   find(queryObject) {
     const query = {
       filters: queryObject ? [getQueryFromQueryObject(queryObject)] : [],
-      outFields: this.schema ? getFieldsFromSchema(this.schema) : ['*'],
+      outFields: ['*'],
       authentication: this.authentication,
     };
 
@@ -59,7 +56,7 @@ export class FeatureLayer {
   findOne(queryObject) {
     const query = {
       filters: queryObject ? [getQueryFromQueryObject(queryObject)] : [],
-      outFields: this.schema ? getFieldsFromSchema(this.schema) : ['*'],
+      outFields: ['*'],
       findOne: true,
       authentication: this.authentication,
     };

--- a/src/model/feature-table.js
+++ b/src/model/feature-table.js
@@ -25,9 +25,6 @@ const getQueryFromQueryObject = queryObject => Object.keys(queryObject)
   .join(' AND ');
 
 
-const getFieldsFromSchema = schema => Object.keys(schema.properties);
-
-
 export class FeatureLayer {
   constructor({
     url,
@@ -49,7 +46,7 @@ export class FeatureLayer {
   find(queryObject) {
     const query = {
       filters: queryObject ? [getQueryFromQueryObject(queryObject)] : [],
-      outFields: this.schema ? getFieldsFromSchema(this.schema) : ['*'],
+      outFields: ['*'],
       authentication: this.authentication,
     };
 
@@ -59,7 +56,7 @@ export class FeatureLayer {
   findOne(queryObject) {
     const query = {
       filters: queryObject ? [getQueryFromQueryObject(queryObject)] : [],
-      outFields: this.schema ? getFieldsFromSchema(this.schema) : ['*'],
+      outFields: ['*'],
       findOne: true,
       authentication: this.authentication,
     };

--- a/src/model/find/fetch-paged-features.js
+++ b/src/model/find/fetch-paged-features.js
@@ -23,6 +23,7 @@ export const fetchPagedFeatures = async (url, authentication, query, inputTime) 
   let exceededTransferLimit = true;
   const features = [];
   let spatialReference = null;
+  let objectIdFieldName = null;
 
   let recordCount = query.resultRecordCount;
   let offset = query.resultOffset;
@@ -33,6 +34,7 @@ export const fetchPagedFeatures = async (url, authentication, query, inputTime) 
 
     features.push(...findResult.features);
     spatialReference = findResult.spatialReference;
+    objectIdFieldName = findResult.objectIdFieldName;
 
     exceededTransferLimit = findResult.exceededTransferLimit === true;
 
@@ -58,6 +60,7 @@ export const fetchPagedFeatures = async (url, authentication, query, inputTime) 
   return {
     features,
     spatialReference,
+    objectIdFieldName,
   };
 };
 

--- a/src/model/find/index.js
+++ b/src/model/find/index.js
@@ -174,7 +174,7 @@ export class Find {
 
     const featureData = await fetchPagedFeatures(queryUrl, this.query.authentication, query);
 
-    const objectIdField = featureData.objectIdField;
+    const objectIdField = featureData.objectIdFieldName;
     const features = featureData.features.map(({ attributes, geometry, centroid }) => ({
       ...(this.query.outStatistics ?
         { attributes } :


### PR DESCRIPTION
The returning of `esriObjectId` was broken. This PR makes it great again.