### PR TITLE
Add organization properties to connect function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgoose",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "",
   "main": "dist/arcgoose.js",
   "module": "dist/arcgoose.js",

--- a/src/connect/index.js
+++ b/src/connect/index.js
@@ -31,6 +31,9 @@ export default async ({ url, portal, portalItemId, authentication }) => {
     type: 'Feature Service',
     url: featureService.url,
     access: featureService.access,
+    owner: featureService.owner,
+    isOrgItem: featureService.isOrgItem,
+    orgId: featureService.orgId,
     capabilities: {
       create: service.capabilities.includes('Create'),
       query: service.capabilities.includes('Query'),


### PR DESCRIPTION
In order to figure out better the access settings of a portal item, I've added the following properties from the item to the arcgoose connection output:

- owner
- isOrgItem
- orgId