### PR TITLE
feature/esri-shape-area 

### DIFF
--- a/src/model/find/fetch-paged-features.js
+++ b/src/model/find/fetch-paged-features.js
@@ -26,6 +26,7 @@ export const fetchPagedFeatures = async (
   const features = [];
   let spatialReference = null;
   let objectIdFieldName = null;
+  let geometryProperties = null;
 
   let recordCount = query.resultRecordCount;
   let offset = query.resultOffset;
@@ -42,6 +43,7 @@ export const fetchPagedFeatures = async (
     features.push(...findResult.features);
     spatialReference = findResult.spatialReference;
     objectIdFieldName = findResult.objectIdFieldName;
+    geometryProperties = findResult.geometryProperties;
 
     exceededTransferLimit = findResult.exceededTransferLimit === true;
 
@@ -68,6 +70,7 @@ export const fetchPagedFeatures = async (
     features,
     spatialReference,
     objectIdFieldName,
+    geometryProperties,
   };
 };
 

--- a/src/model/find/filter-attributes.js
+++ b/src/model/find/filter-attributes.js
@@ -23,12 +23,15 @@ export const filterAttributes = (
   schema,
   validator,
   esriObjectIdField,
+  esriShapeAreaField,
 ) => {
   if (!schema) return attributes;
 
   const cleanAttributes = parseNonEsriTypesRead(attributes, schema);
   const esriObjectId = attributes[esriObjectIdField];
-
+  const esriShapeArea = esriShapeAreaField
+    ? attributes[esriShapeAreaField]
+    : undefined;
   let validationError;
 
   if (validator) {
@@ -44,6 +47,7 @@ export const filterAttributes = (
     attributes: {
       ...parsedAttributes,
       esriObjectId,
+      esriShapeArea,
     },
     ...(validator ? { validation: validationError } : null),
   };

--- a/src/model/find/index.js
+++ b/src/model/find/index.js
@@ -182,6 +182,9 @@ export class Find {
     );
 
     const esriObjectIdField = featureData.objectIdFieldName;
+    const esriShapeAreaField =
+      featureData.geometryProperties &&
+      featureData.geometryProperties.shapeAreaFieldName;
 
     let validator = null;
     if (this.validation) {
@@ -199,6 +202,7 @@ export class Find {
               this.schema,
               validator,
               esriObjectIdField,
+              esriShapeAreaField,
             )),
         geometry: this.query.returnGeometry
           ? {


### PR DESCRIPTION
This follows the same pattern as the `esriObjectId` to add `esri` prefixed attributes for these auto-generated esri-internal attributes.