### PR TITLE
Feature/Override flag for rollbackOnFailure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgoose",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "",
   "main": "dist/arcgoose.js",
   "module": "dist/arcgoose.js",

--- a/src/model/apply-edits/index.js
+++ b/src/model/apply-edits/index.js
@@ -76,7 +76,7 @@ export class ApplyEdits {
     return this;
   }
 
-  rollbackOnFailure(setting) {
+  rollbackOnFailure() {
     this.shouldRollbackOnFailure = true;
     return this;
   }

--- a/src/model/apply-edits/index.js
+++ b/src/model/apply-edits/index.js
@@ -43,7 +43,7 @@ export class ApplyEdits {
     this.deletes = [];
     this.updates = [];
     this.shouldUseGlobalIds = true;
-    this.shouldRollbackOnFailure = true;
+    this.shouldRollbackOnFailure = false;
     this.authentication = authentication;
   }
 

--- a/src/model/apply-edits/index.js
+++ b/src/model/apply-edits/index.js
@@ -43,6 +43,7 @@ export class ApplyEdits {
     this.deletes = [];
     this.updates = [];
     this.shouldUseGlobalIds = true;
+    this.shouldRollbackOnFailure = true;
     this.authentication = authentication;
   }
 
@@ -75,6 +76,11 @@ export class ApplyEdits {
     return this;
   }
 
+  rollbackOnFailure(setting) {
+    this.shouldRollbackOnFailure = setting;
+    return this;
+  }
+
   handle() {
     return {
       serviceUrl: this.featureLayer.serviceUrl,
@@ -102,7 +108,7 @@ export class ApplyEdits {
     const query = {
       authentication: this.authentication,
       useGlobalIds: this.shouldUseGlobalIds,
-      rollbackOnFailure: true,
+      rollbackOnFailure: this.shouldRollbackOnFailure,
       adds: this.adds.length ? JSON.stringify(this.adds) : null,
       updates: this.updates.length ? JSON.stringify(this.updates) : null,
       deletes: deleteIds,

--- a/src/model/apply-edits/index.js
+++ b/src/model/apply-edits/index.js
@@ -77,7 +77,7 @@ export class ApplyEdits {
   }
 
   rollbackOnFailure(setting) {
-    this.shouldRollbackOnFailure = setting;
+    this.shouldRollbackOnFailure = true;
     return this;
   }
 


### PR DESCRIPTION
This adds an option to override `rollbackOnFailure` for the apply edits.

This does not touch `deleteWhere`, which I don't think is needed.