### PR TITLE
Feature/rollback on failure 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgoose",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "",
   "main": "dist/arcgoose.js",
   "module": "dist/arcgoose.js",

--- a/src/model/apply-edits/index.js
+++ b/src/model/apply-edits/index.js
@@ -86,6 +86,7 @@ export class ApplyEdits {
       serviceUrl: this.featureLayer.serviceUrl,
       name: this.featureLayer.name,
       authentication: this.authentication,
+      rollbackOnFailure: shouldRollbackOnFailure,
       payload: {
         id: this.featureLayer.id,
         adds: this.adds.length ? this.adds : null,

--- a/src/model/apply-edits/index.js
+++ b/src/model/apply-edits/index.js
@@ -86,7 +86,7 @@ export class ApplyEdits {
       serviceUrl: this.featureLayer.serviceUrl,
       name: this.featureLayer.name,
       authentication: this.authentication,
-      rollbackOnFailure: shouldRollbackOnFailure,
+      rollbackOnFailure: this.shouldRollbackOnFailure,
       payload: {
         id: this.featureLayer.id,
         adds: this.adds.length ? this.adds : null,

--- a/src/model/exec-all.js
+++ b/src/model/exec-all.js
@@ -97,6 +97,7 @@ export default async (handleArray, progressCallback) => {
 
   const serviceUrl = handleArray[0].serviceUrl;
   const authentication = handleArray[0].authentication;
+  const rollbackOnFailure = handleArray[0].rollbackOnFailure;
 
   const editsArray = flattenEditHandles(handleArray);
   const editChunks = getChunks(editsArray);
@@ -107,7 +108,7 @@ export default async (handleArray, progressCallback) => {
     const edits = expandEdits(editChunks[i]);
     const query = {
       useGlobalIds: true,
-      rollbackOnFailure: true,
+      rollbackOnFailure,
       edits: JSON.stringify(edits),
     };
 


### PR DESCRIPTION
It seems like I missed an occurence of `rollbackOnFailure` in `execAll()`.

Similar to `serviceUrl` and `authentication`, this will just take the `rollbackOnFailure` setting from the first handle.