### PR TITLE
Handle large arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgoose",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "",
   "main": "dist/arcgoose.js",
   "module": "dist/arcgoose.js",

--- a/src/model/apply-edits/index.js
+++ b/src/model/apply-edits/index.js
@@ -48,21 +48,32 @@ export class ApplyEdits {
   }
 
   add(features) {
-    this.adds.push(
-      ...parseCreate(features, { schema: this.schema, ajv: this.ajv }),
+    parseCreate(features, { schema: this.schema, ajv: this.ajv }).forEach(
+      (feature) => {
+        this.adds.push(feature);
+      },
+      this,
     );
+
     return this;
   }
 
   update(features) {
-    this.updates.push(
-      ...parseUpdate(features, { schema: this.schema, ajv: this.ajv }),
+    parseUpdate(features, { schema: this.schema, ajv: this.ajv }).forEach(
+      (feature) => {
+        this.updates.push(feature);
+      },
+      this,
     );
+
     return this;
   }
 
   delete(idArray) {
-    this.deletes.push(...parseDelete(idArray));
+    parseDelete(idArray).forEach((feature) => {
+      this.deletes.push(feature);
+    }, this);
+
     return this;
   }
 

--- a/src/model/exec-all.js
+++ b/src/model/exec-all.js
@@ -26,27 +26,29 @@ const flattenEditHandles = (handleArray) => {
   const editsArray = [];
 
   handleArray.forEach((handle) => {
-    editsArray.push(
-      ...(handle.payload.adds || []).map((payload) => ({
+    (handle.payload.adds || []).forEach((payload) => {
+      editsArray.push({
         id: handle.payload.id,
         type: 'adds',
         payload,
-      })),
-    );
-    editsArray.push(
-      ...(handle.payload.deletes || []).map((payload) => ({
+      });
+    });
+
+    (handle.payload.deletes || []).forEach((payload) => {
+      editsArray.push({
         id: handle.payload.id,
         type: 'deletes',
         payload,
-      })),
-    );
-    editsArray.push(
-      ...(handle.payload.updates || []).map((payload) => ({
+      });
+    });
+
+    (handle.payload.updates || []).forEach((payload) => {
+      editsArray.push({
         id: handle.payload.id,
         type: 'updates',
         payload,
-      })),
-    );
+      });
+    });
   });
 
   return editsArray;


### PR DESCRIPTION
### REVIEW CAREFULLY!

`array.push(...otherArray)` has memory limits and cannot handle arrays >150k (for chrome)

`array.push` with destructuring gets compiled to an `array.push.apply()` by webpack and `.apply` has arguments limits.

> But beware: by using apply this way, you run the risk of exceeding the JavaScript engine's argument length limit. The consequences of applying a function with too many arguments (that is, more than tens of thousands of arguments) varies across engines. (The JavaScriptCore engine has hard-coded argument limit of 65536.

The solution seems to be to use a loop-based approach:

https://stackoverflow.com/questions/1374126/how-to-extend-an-existing-javascript-array-with-another-array-without-creating/17368101#17368101

I tested this with an array of 300k parcels.