### PR TITLE
Reduce chunk size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgoose",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "",
   "main": "dist/arcgoose.js",
   "module": "dist/arcgoose.js",

--- a/src/model/exec-all.js
+++ b/src/model/exec-all.js
@@ -20,7 +20,7 @@ import {
   processResultsOIDs,
 } from './apply-edits/process-results';
 
-const CHUNK_SIZE = 500;
+const CHUNK_SIZE = 300;
 
 const flattenEditHandles = (handleArray) => {
   const editsArray = [];

--- a/src/model/exec-all.js
+++ b/src/model/exec-all.js
@@ -20,7 +20,7 @@ import {
   processResultsOIDs,
 } from './apply-edits/process-results';
 
-const CHUNK_SIZE = 300;
+const CHUNK_SIZE = 200;
 
 const flattenEditHandles = (handleArray) => {
   const editsArray = [];


### PR DESCRIPTION
500 is too large. It leads to a lot of timeouts when writing lots of data.

200 seems to be more reasonable. The overhead of the request is negligible compared to the amount of time the server takes to process the data.