### PR TITLE
Partial Schema: Filter out allOf 

### DIFF
--- a/src/model/index.js
+++ b/src/model/index.js
@@ -30,6 +30,7 @@ export default ({ type, ...otherParams }, schema) => {
     ['if']: no1, // eslint-disable-line no-useless-computed-key
     ['then']: no2, // eslint-disable-line no-useless-computed-key
     ['else']: no3, // eslint-disable-line no-useless-computed-key
+    ['allOf']: no4, // eslint-disable-line no-useless-computed-key
     ...partialSchema
   } = schema;
 


### PR DESCRIPTION
Add `allOf` to filtering before assigning partial schema. An oversight of #40, the building types schema has a property `allOf` that isn't filtered out. This is a hotfix & should be investigated & refactored in the aftermath.